### PR TITLE
Adding support for cached RPM keys and yum group installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ In addition to the primary user-facing command (`up`), Provisio provides a small
 Provisio uses cacheing to create an explicit manifest of dependencies and support off-line, read-only (e.g. CD-ROM) and archival provisioning. The cache is kept in a `.provisio` directory beside the Provisiofile.
 
     $ provisio install [ yum | apt | rpm | pip | npm | npm-global ] <package>
+    $ provisio install rpm-key <package> <url>
     
 performs a managed software install using the local cache. If no package manager is supplied, Provisio will try to infer one at runtime which can offer a degree of platform independence for common packages. 
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ In addition to the primary user-facing command (`up`), Provisio provides a small
 
 Provisio uses cacheing to create an explicit manifest of dependencies and support off-line, read-only (e.g. CD-ROM) and archival provisioning. The cache is kept in a `.provisio` directory beside the Provisiofile.
 
-    $ provisio install [ yum | apt | rpm | pip | npm | npm-global ] <package>
+    $ provisio install [ yum | yum-group | apt | rpm | pip | npm | npm-global ] <package>
     $ provisio install rpm-key <package> <url>
     
 performs a managed software install using the local cache. If no package manager is supplied, Provisio will try to infer one at runtime which can offer a degree of platform independence for common packages. 

--- a/provisio
+++ b/provisio
@@ -215,6 +215,19 @@ EOF
         rpm -ivh $BASE/download/$file.rpm
     ;;
 
+    rpm-key)
+        url=$3
+        if grep -Fxq "import-$app" $BASE/manifest  
+        then
+            rpm --import $BASE/rpm-keys/$app
+        else
+            curl -o $BASE/rpm-keys/$app "$url"
+            cat $BASE/rpm-keys/$app
+            rpm --import $BASE/rpm-keys/$app
+            echo "import-$app" >> $BASE/manifest  
+        fi
+    ;;
+
     # Special cases...
 
     jdk)

--- a/provisio
+++ b/provisio
@@ -23,6 +23,7 @@ SCRATCH=/var/log/provisio/$DIGEST
 
 mkdir -p $SCRATCH
 mkdir -p $BASE
+mkdir -p $BASE/rpm-keys
 if [ ! -f $BASE/manifest ]; then
     touch $BASE/manifest
 fi

--- a/provisio
+++ b/provisio
@@ -123,9 +123,9 @@ EOF
 
         if grep -Fxq $tag $BASE/manifest  
         then
-            yum -y -C groupinstall $app
+            yum -y -C groupinstall "$app"
         else
-            yum -y groupinstall $app
+            yum -y groupinstall "$app"
             echo $tag >> $BASE/manifest    
         fi
 

--- a/provisio
+++ b/provisio
@@ -216,7 +216,7 @@ EOF
     ;;
 
     rpm-key)
-        url=$3
+        url=$4
         if grep -Fxq "import-$app" $BASE/manifest  
         then
             rpm --import $BASE/rpm-keys/$app

--- a/provisio
+++ b/provisio
@@ -114,6 +114,26 @@ EOF
 
       ;;
 
+    yum-group)
+        mkdir -p $BASE/yum
+
+        cp /etc/yum.conf /etc/yum.conf.bak
+        sed -i "s/keepcache=0/keepcache=1/" /etc/yum.conf
+        sed -i "s@cachedir=.*@cachedir=$BASE/yum/repo@" /etc/yum.conf
+
+        if grep -Fxq $tag $BASE/manifest  
+        then
+            yum -y -C groupinstall $app
+        else
+            yum -y groupinstall $app
+            echo $tag >> $BASE/manifest    
+        fi
+
+        mv /etc/yum.conf /etc/yum.conf.temp
+        mv /etc/yum.conf.bak /etc/yum.conf
+
+      ;;
+
 
     pip)
         mkdir -p $BASE/pip


### PR DESCRIPTION
Add 'provisio install rpm-key <app_name> <url>' and 'provisio install yum-group <app>' commands.
Updated the readme to reflect these changes.
