### PR TITLE
Additions to pull command

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,16 @@ For all other cases
 
 downloads and caches a remote dependency. The (possibly cached) file will appear "downloaded" to the /tmp directory because the working directory may be read-only at provision-time.
 
+Additionally, for git repositories
+    
+    $ provisio pull [-f] [--no-up] <org-name>/<repo-name>
+
+clones or pulls a repository from `github`. By default this will clone the first time it is run and always use the cached version after that. The `-f` flag forces a pull from the internet. If the repository itself contains a `Provisiofile` at the top level, `provisio up` will run automatically on the repo. To prevent this behaviour, use the `--no-up` flag.
+
+If everything is contained in a git repository with a `Provisiofile` at the top level, running `provisio pull <org-name>/<repo-name>` is an alternative for running `provisio up`.
+
+The (possibly cached) repository will appear "cloned" to the /tmp directory.
+
 ### Configuration utilities
 
 Provisio provides some simple commands to aid local configuration and reduce line noise.

--- a/provisio
+++ b/provisio
@@ -626,13 +626,30 @@ EOF
     name=$2
     env=$3
     force=
-      
+    no_up=
+
+    # If -f or --no-up flag supplied, shift other arguments along
     if [ "$name" == "-f" ]; then
         name=$3
         env=$4 
-        force=1           
+        force=1   
+    elif [ "$name" == "--no-up" ]; then
+        name=$3
+        env=$4 
+        no_up=1
     fi
     
+    # If a second -f or --no-up flag supplied, shift other arguments along
+    if [ "$name" == "-f" ]; then
+        name=$4
+        env=$5
+        force=1   
+    elif [ "$name" == "--no-up" ]; then
+        name=$4
+        env=$5
+        no_up=1
+    fi
+
     org=$(echo -n $name | sed 's@/.*@@')
     repo=$(echo -n $name | sed 's@.*/@@')
 
@@ -657,10 +674,13 @@ EOF
             git pull https://github.com/$org/$repo
         fi
         if [ -e ./Provisiofile ]; then
-            provisio up $env
+            if [ -z "$no_up" ]; then
+                provisio up $env
+            fi
         fi
     popd
 
+    cp -r $BASE/git/$repo /tmp/$repo
 
     ;;
 
@@ -710,7 +730,7 @@ EOF
     echo "       provisio download <URL>"    
     echo "       provisio install [ yum | apt | rpm | pip | npm | npm-global ] <package>"
     echo "       provisio install jdk [version]"  
-    echo "       provisio pull <org>/<repo> [environment]"       
+    echo "       provisio pull [-f] [--no-up] <org>/<repo> [environment]"       
     echo ""
     echo "       provisio set <key> <value> <file>"
     echo "       provisio get <key> <file>"    


### PR DESCRIPTION
Hi Chris,

There were some things I wanted to do with git pull which `provisio` didn't seem to do, so I've added them. Let me know if you've got any comments / if any of these things aren't what `provisio` is intended for. If you'd like the changes then please merge! Current behaviour should not be affected.

* Repo is now 'cloned' into the `/tmp` directory (similar to what `provisio download` does) so that is accessible somewhere other than inside the `.provisio` folder
* A `--no-up` flag is available which suppresses the automatic running of `provisio` on a cloned repo which has a `Provisiofile` in the top level directory
* Added some info about `provisio pull` to `README.md`