### PR TITLE
Add -d option for duplicating output lines instead of overwrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ To make provisio additionally print all output to the screen, use _verbose mode_
 
     $ provisio up -v
 
+To make provisio duplicate each item (once with a 'started' message and once with a 'success' message) instead of trying to overwrite the console output, use _duplicate mode_. This is useful if you're using a console or logging system around provisio which doesn't play well with `\r` characters:
+
+    $ provisio up -d
+
 To view logs live as provisio is running (in a separate shell)
 
     $ provisio watch [num_lines]

--- a/provisio
+++ b/provisio
@@ -37,7 +37,11 @@ case "$1" in
     if [ ! -z "$VERBOSE" ]; then
         provisio up -v
     else
-        provisio up
+        if [ ! -z "$DUPLICATE" ]; then
+            provisio up -d
+        else
+            provisio up
+        fi
     fi
     ec=$?
     cd $cwd
@@ -702,12 +706,22 @@ EOF
 
     env=$2
     verbose=
+    duplicate=
 
     if [ "$env" == "-v" ]; then
         env=$3
         verbose=1
+    elif [ "$env" == "-d" ]; then
+        env=$3
+        duplicate=1
     fi
-
+    if [ "$env" == "-v" ]; then
+        env=$4
+        verbose=1
+    elif [ "$env" == "-d" ]; then
+        env=$4
+        duplicate=1
+    fi
 
     # FIXME: apart from being an annoying dependency
     # this can break due to build/deploy parity mismatch
@@ -748,16 +762,14 @@ EOF
     if [ ! -z "$verbose" ]; then
         START_COMMAND='printf "\n\e[94mStarted task $1\e[39m\n"'
         STDOUT_REDIRECT=' >(tee '"$LOG_FILE"')'
-        BACKSPACES=''
         END_COMMAND='sleep 0.5'
     else
-        START_COMMAND='printf "%-50s[\e[94mrunning\e[39m]" "$1"'
+        NEWLINE=''
+        if [ ! -z "$duplicate" ]; then
+            NEWLINE='\n'
+        fi
+        START_COMMAND='printf "%-50s[\e[94mstarted\e[39m]'"$NEWLINE"'" "$1"'
         STDOUT_REDIRECT="$LOG_FILE"
-        BACKSPACES=''
-        for i in `seq 1 59`;  # This is the number of characters printed by the start command
-        do
-            BACKSPACES+='\b'
-        done 
         END_COMMAND=''
     fi
 
@@ -773,19 +785,25 @@ EOF
     MAIN_COMMAND+='trap - EXIT\n'
     MAIN_COMMAND+='touch '"$SCRATCH"'/$1.success\n'
     MAIN_COMMAND+='exec 1>&3 2>&4\n'
-    MAIN_COMMAND+='set +e\n'   
-    MAIN_COMMAND+='printf "'"$BACKSPACES"'%-50s[\e[32msuccess\e[39m]\n" "$1"\n'
+    MAIN_COMMAND+='set +e\n'
+    LINERETURN=''
+    if [ -z "$duplicate" ]; then #If not duplicating
+        if [ -z "$verbose" ]; then #If not verbose
+            LINERETURN='\r' # Then return to the start of the line to overwrite
+        fi
+    fi  
+    MAIN_COMMAND+='printf "'"$LINERETURN"'%-50s[\e[32msuccess\e[39m]\n" "$1"\n'
     
     perl -0777 -pi -e 's|#task\h+(\S+)\h+once(.*?)#end|if [ ! -f '"$SCRATCH"'/$1.success ]; then\n'"$MAIN_COMMAND"'\nelse\nprintf "%-50s[skipped]\n" "$1"\nfi|sg' $SCRATCH/$PROVISIOFILE.sh 
     perl -0777 -pi -e 's|#task\h+(\S+)\h+always(.*?)#end|'"$MAIN_COMMAND"'|sg' $SCRATCH/$PROVISIOFILE.sh
     
-    VERBOSE="$verbose" bash $SCRATCH/$PROVISIOFILE.sh
+    VERBOSE="$verbose" DUPLICATE="$duplicate" bash $SCRATCH/$PROVISIOFILE.sh
     
     ;;
 
   *)
     echo ""
-    echo "Usage: provisio up [-v] [environment]"
+    echo "Usage: provisio up [-v] [-d] [environment]"
     echo ""
     echo "       provisio download <URL>"    
     echo "       provisio install [ yum | apt | rpm | pip | npm | npm-global ] <package>"

--- a/provisio
+++ b/provisio
@@ -748,10 +748,16 @@ EOF
     if [ ! -z "$verbose" ]; then
         START_COMMAND='printf "\n\e[94mStarted task $1\e[39m\n"'
         STDOUT_REDIRECT=' >(tee '"$LOG_FILE"')'
+        BACKSPACES=''
         END_COMMAND='sleep 0.5'
     else
-        START_COMMAND='printf "\r%-50s[\e[94mrunning\e[39m]" "$1"'
+        START_COMMAND='printf "%-50s[\e[94mrunning\e[39m]" "$1"'
         STDOUT_REDIRECT="$LOG_FILE"
+        BACKSPACES=''
+        for i in `seq 1 59`;  # This is the number of characters printed by the start command
+        do
+            BACKSPACES+='\b'
+        done 
         END_COMMAND=''
     fi
 
@@ -767,8 +773,8 @@ EOF
     MAIN_COMMAND+='trap - EXIT\n'
     MAIN_COMMAND+='touch '"$SCRATCH"'/$1.success\n'
     MAIN_COMMAND+='exec 1>&3 2>&4\n'
-    MAIN_COMMAND+='set +e\n'
-    MAIN_COMMAND+='printf "\r%-50s[\e[32msuccess\e[39m]\n" "$1"\n'
+    MAIN_COMMAND+='set +e\n'   
+    MAIN_COMMAND+='printf "'"$BACKSPACES"'%-50s[\e[32msuccess\e[39m]\n" "$1"\n'
     
     perl -0777 -pi -e 's|#task\h+(\S+)\h+once(.*?)#end|if [ ! -f '"$SCRATCH"'/$1.success ]; then\n'"$MAIN_COMMAND"'\nelse\nprintf "%-50s[skipped]\n" "$1"\nfi|sg' $SCRATCH/$PROVISIOFILE.sh 
     perl -0777 -pi -e 's|#task\h+(\S+)\h+always(.*?)#end|'"$MAIN_COMMAND"'|sg' $SCRATCH/$PROVISIOFILE.sh


### PR DESCRIPTION
[running] being replaced with [success] seems to work well in some consoles, but for example when being run as a provisioner by vagrant, the logs coming out on the host terminal get a bit messed up by `\r` or `\b` characters. So there's a `-d` flag to duplicate the task name with a started/success message at the start and end of each task, which can be used if the display for a particular use case doesn't look any good

So with the `-d` flag, output looks something like this
```
my_task_1                   [started]
my_task_1                   [success]
my_task_2                   [started]
my_task_2                   [success]
```

Without it, the output is as before - says [started] which is then overwritten by [success] when the task completes.